### PR TITLE
fix(pragmatic-review): use fully-qualified subagent type name

### DIFF
--- a/commands/pragmatic-review.md
+++ b/commands/pragmatic-review.md
@@ -46,7 +46,7 @@ Before reviewing any code, understand the project structure.
 
 </step>
 
-<step number="2" subagent="code-reviewer" name="review_all_code">
+<step number="2" subagent="feature-dev:code-reviewer" name="review_all_code">
 
 ### Step 2: Code Review
 


### PR DESCRIPTION
## Summary
- Fix subagent type name from `code-reviewer` to `feature-dev:code-reviewer` in pragmatic-review command

Closes #3