### PR TITLE
fix(pragmatic-review): remove non-standard frontmatter fields

### DIFF
--- a/commands/pragmatic-review.md
+++ b/commands/pragmatic-review.md
@@ -1,9 +1,7 @@
 ---
 description: Pragmatic Code Review
-globs:
 alwaysApply: false
 version: 2.0
-encoding: UTF-8
 ---
 
 # Pragmatic Code Review Command


### PR DESCRIPTION
## Summary
- Remove empty `globs:` and `encoding: UTF-8` fields from pragmatic-review command frontmatter

Closes #5