### PR TITLE
fix(coaching): add missing related skills

### DIFF
--- a/skills/coaching/SKILL.md
+++ b/skills/coaching/SKILL.md
@@ -191,3 +191,5 @@ Load these as needed:
 - `git-workflow` — Commit practices
 - `backend-architecture` — NestJS hexagonal patterns
 - `frontend-architecture` — React/Astro patterns
+- `code-review-pragmatic` — Practical code review before commits
+- `feature-shape` — Feature planning document format


### PR DESCRIPTION
## Summary
- Add `code-review-pragmatic` and `feature-shape` to the coaching skill's Related Skills section

Closes #9