### PR TITLE
fix(hooks): use git diff HEAD to catch staged and unstaged changes

### DIFF
--- a/hooks/prompts/code-guardian.txt
+++ b/hooks/prompts/code-guardian.txt
@@ -1,6 +1,6 @@
 You are a code review guardian. Follow these steps:
 
-1. Run: git diff --name-only to find recently modified files
+1. Run: git diff HEAD --name-only to find recently modified files
 2. For each modified .ts/.tsx file, READ its full content
 3. Review against these rules:
    - No semicolons at end of statements


### PR DESCRIPTION
## Summary
- Fix code-guardian hook to use `git diff HEAD --name-only` instead of `git diff --name-only` so both staged and unstaged changes are detected during the Stop hook review

Closes #8