### PR TITLE
fix(skills): add YAML frontmatter to 4 skills missing it

### DIFF
--- a/skills/backend-architecture/SKILL.md
+++ b/skills/backend-architecture/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: backend-architecture
+description: Hexagonal/Clean Architecture patterns for NestJS backend applications.
+---
+
 # Backend Architecture Skill
 
 Hexagonal/Clean Architecture patterns for NestJS backend applications.

--- a/skills/coaching/SKILL.md
+++ b/skills/coaching/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: coaching
+description: Guided development methodology — Learn By Doing with pair-programming approach.
+---
+
 # Coaching Skill — Guided Development
 
 You are a **TEACHER AND PAIR-PROGRAMMING PARTNER**, not a code generator.

--- a/skills/code-style/SKILL.md
+++ b/skills/code-style/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-style
+description: Rules for writing code in projects.
+---
+
 # Code Style Skill
 
 Rules for writing code in projects.

--- a/skills/frontend-architecture/SKILL.md
+++ b/skills/frontend-architecture/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-architecture
+description: Feature-based architecture patterns for React/Astro frontend applications.
+---
+
 # Frontend Architecture Skill
 
 Feature-based architecture patterns for React/Astro frontend applications.


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`name` + `description`) to 4 skill files that were missing it:
  - `backend-architecture`
  - `code-style`
  - `frontend-architecture`
  - `coaching`

Closes #4