### PR TITLE
fix(planning): resolve nested code blocks in plan template

### DIFF
--- a/commands/planning.md
+++ b/commands/planning.md
@@ -87,7 +87,7 @@ Address any open questions from the Feature Shape before planning.
 Generate a detailed Implementation Plan following the established pattern.
 
 <plan_structure>
-```markdown
+~~~markdown
 # Feature NN: [Feature Name] — Implementation Plan
 
 ## Overview
@@ -233,7 +233,7 @@ apps/web/src/features/[feature]/
 |------|--------|
 | `apps/api/src/app.module.ts` | Import new module |
 | `apps/web/src/layouts/Main.astro` | Add navigation |
-```
+~~~
 </plan_structure>
 
 <phase_guidelines>


### PR DESCRIPTION
## Summary
- Replace outer backtick code fences with tilde fences (`~~~`) in the plan template structure
- Inner code blocks (`bash`, `text`) remain as backtick fences
- Fixes standard markdown parsing of nested code blocks

Closes #22

## Test plan
- [ ] Verify `commands/planning.md` renders correctly as standard markdown
- [ ] Verify inner `bash` and `text` code blocks display correctly
- [ ] Verify generated plans maintain the same structure and content