### PR TITLE
fix(coaching): integrate git-workflow into coaching checkpoint

### DIFF
--- a/commands/coaching.md
+++ b/commands/coaching.md
@@ -156,10 +156,12 @@ When developer says they're done, use the **coaching-review** agent behavior.
 At logical stopping points (end of phase, several units complete, developer requests), analyze all completed units and propose a **commit sequence**.
 
 <commit_strategy>
-Rules (from git-workflow skill):
+From git-workflow skill:
 - One logical change per commit (component + its test + its barrel export = one commit)
-- Dependency order: shared/utility code BEFORE units that import them
 - Never mix commit types: feat separate from refactor separate from docs
+
+Coaching-specific checkpoint rules:
+- Dependency order: shared/utility code BEFORE units that import them
 - PROGRESS.md is ALWAYS its own docs(scope) commit, never mixed with code
 - Propose the FULL commit sequence with messages before executing any commit
 </commit_strategy>
@@ -180,12 +182,14 @@ Proposed commit sequence:
 3. docs([scope]): update PROGRESS.md — files: PROGRESS.md
 
 Ready to commit this sequence?
+
+Next up: [brief preview of upcoming unit or phase]
 ```
 </output_format>
 
 <instructions>
   ACTION: Propose full atomic commit sequence at logical checkpoints
-  FOLLOW: git-workflow skill rules for commit granularity and ordering
+  FOLLOW: git-workflow skill for commit granularity and message format; apply dependency ordering as coaching-specific rule
   WAIT: For developer approval before executing any commit
   UPDATE: PROGRESS.md checkboxes as a separate docs commit after code commits
   PREVIEW: What comes next after the checkpoint


### PR DESCRIPTION
## Summary
- Replace single-commit checkpoint (Step 5) with **multi-commit strategy**
- Add `commit_strategy` block with rules from git-workflow skill
- Propose full atomic commit sequence with dependency ordering before executing
- PROGRESS.md always gets its own separate `docs(scope)` commit
- Developer approves the full sequence before any commit runs

Closes #19

## Test plan
- [x] Verify Step 5 proposes multiple atomic commits, not a single commit
- [x] Verify Step 5 explicitly requires dependency order
- [x] Verify Step 5 separates docs commits from code commits
- [x] Verify Step 5 includes barrel exports with their component
- [x] Verify git-workflow skill is referenced in coaching.md