### PR TITLE
feat: add /ship post-implementation shipping pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ Run `/coaching` to start a guided implementation session.
 | `/planning`        | Create Implementation Plan from Feature Shape |
 | `/coaching`        | Guided implementation session                |
 | `/pragmatic-review`| Code review                                  |
+| `/ship`            | Ship code — scan, commit, push, PR           |
 | `/commit`          | Create atomic commit                         |
 | `/commit-push-pr`  | Commit + push + create PR                    |
 
@@ -213,6 +214,10 @@ bun run format:check
 | `coaching-review` | Real code review before commit (logic, types, consistency) |
 | `coaching-context` | Gathers project context for coaching sessions |
 | `coaching-auditor` | Audits coaching responses against skill rules |
+| `ship-scanner`  | Scans changed files for convention violations |
+| `ship-planner`  | Plans atomic commit sequence from diff |
+| `ship-verifier` | Runs all verification checks (test, typecheck, lint, format) |
+| `ship-progress` | Proposes PROGRESS.md checkbox updates |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ Personal collection of skills, commands, agents, and configurations for Claude C
 │   ├── coaching.md
 │   ├── planning.md
 │   ├── pragmatic-review.md
+│   ├── ship.md
 │   └── start.md
 ├── agents/                # Specialized agent behaviors
 │   ├── coaching-auditor.md
 │   ├── coaching-context.md
 │   ├── coaching-guide.md
 │   ├── coaching-review.md
-│   └── coaching-scaffold.md
+│   ├── coaching-scaffold.md
+│   ├── ship-planner.md
+│   ├── ship-progress.md
+│   ├── ship-scanner.md
+│   └── ship-verifier.md
 ├── hooks/                 # Claude Code hooks (injected into settings.json)
 │   ├── hooks-config.json
 │   └── prompts/
@@ -56,6 +61,7 @@ Personal collection of skills, commands, agents, and configurations for Claude C
 | `/coaching`         | Start a guided implementation session                     |
 | `/planning`         | Create Implementation Plan from Feature Shape             |
 | `/pragmatic-review` | Pragmatic code review                                     |
+| `/ship`             | Ship code — scan, commit, push, PR                        |
 
 ## Agents
 
@@ -66,6 +72,10 @@ Personal collection of skills, commands, agents, and configurations for Claude C
 | `coaching-scaffold` | Creates placeholder file pairs (impl + test)          |
 | `coaching-guide`    | Analyzes context and provides guidance with examples  |
 | `coaching-review`   | Code review before commit (logic, types, consistency) |
+| `ship-scanner`      | Scans changed files for convention violations         |
+| `ship-planner`      | Plans atomic commit sequence from diff                |
+| `ship-verifier`     | Runs all verification checks (test, typecheck, lint, format) |
+| `ship-progress`     | Proposes PROGRESS.md checkbox updates                 |
 
 ## Hooks
 
@@ -102,6 +112,7 @@ graph TB
             C3["⌘ coaching"]
             C4["⌘ pragmatic-review"]
             C5["⌘ coach"]
+            C6["⌘ ship"]
         end
 
         subgraph "Agents (behavior refs)"
@@ -110,6 +121,10 @@ graph TB
             A3[coaching-review]
             A4[coaching-context]
             A5[coaching-auditor]
+            A6[ship-scanner]
+            A7[ship-planner]
+            A8[ship-verifier]
+            A9[ship-progress]
         end
 
         subgraph "Hooks (auto-fired)"
@@ -134,6 +149,12 @@ graph TB
     C5 -->|"spawns"| A3
     C5 -->|"spawns"| A5
     C5 -->|"follows"| S5
+
+    C6 -->|"spawns"| A6
+    C6 -->|"spawns"| A7
+    C6 -->|"spawns"| A8
+    C6 -->|"spawns"| A9
+    C6 -->|"follows"| S4
 
     H1 -->|"enforces"| S4
     H3 -->|"enforces"| S3

--- a/agents/ship-planner.md
+++ b/agents/ship-planner.md
@@ -58,10 +58,30 @@ For each changed file, determine:
 
 ### Step 3: Group into Atomic Commits
 
+**CRITICAL CONSTRAINT: Each file MUST appear in exactly ONE commit.** A file that was modified for
+multiple purposes belongs to the commit with the primary/broadest change. Never try to split changes
+within a single file into separate commits.
+
+- **Group by files actually touched**, not by abstract logical units. If two logical units modify the
+  same files, they are ONE commit.
+- When a single file contains changes for multiple logical units (e.g., a Container with create,
+  edit, AND delete flows added), they ALL go in ONE commit because they are ONE file.
 - **Implementation + test + barrel export** of the same logical unit = one commit
 - **NEVER mix commit types** — `feat` and `refactor` go in separate commits
 - **Config/tooling changes** that support a feature go in a `chore` commit before the `feat`
 - **PROGRESS.md** is ALWAYS its own `docs()` commit — the LAST commit in the sequence
+- **When in doubt, fewer larger commits are better** than many small commits with file conflicts
+
+### Step 3b: Validate Grouping
+
+After grouping, **scan the commit plan to verify no file appears in more than one commit:**
+
+1. Build a set of all files across all planned commits
+2. Check for duplicates — any file appearing in 2+ commits is a violation
+3. If duplicates found: **merge those commits into one**, re-deriving the commit type from the
+   dominant change type (e.g., if merging a `feat` and a `refactor` that touch the same files,
+   use `feat` since it's the primary purpose)
+4. Re-validate after merging — repeat until no duplicates remain
 
 ### Step 4: Order by Dependency
 
@@ -125,5 +145,7 @@ COMMIT 2:
 - **NEVER** include AI attribution in commit messages
 - **NEVER** create empty commits (no files = no commit)
 - **NEVER** mix commit types in a single commit
+- **NEVER** place the same file in multiple commits — merge those commits instead
 - **NEVER** modify any files — this agent only plans, it does not execute
 - If only one logical change exists, produce a single commit (no need to split artificially)
+- When in doubt, fewer larger commits are better than many small commits with file conflicts

--- a/agents/ship-planner.md
+++ b/agents/ship-planner.md
@@ -1,0 +1,129 @@
+---
+name: ship-planner
+description:
+  Plans atomic commit sequence from changed files — groups by type/scope, orders by dependency,
+  generates conventional commit messages per git-workflow skill.
+---
+
+# Agent: ship-planner
+
+Plans an atomic commit sequence from changed files, following git-workflow conventions.
+
+## Purpose
+
+This agent is the "strategist" of the shipping pipeline — it analyzes the diff and produces an
+ordered sequence of atomic commits that follow project conventions. It is designed to be spawned as a
+sub-agent via the Task tool.
+
+## Input
+
+The agent receives:
+
+- The pre-flight context block from the ship command (branch, changed files list, monorepo info)
+- Access to the full git diff (staged + unstaged)
+
+## Behavior
+
+### Step 1: Analyze Changes
+
+- Run `git diff HEAD` and `git diff --cached` to capture all changes
+- Run `git status --porcelain` to identify new/modified/deleted files
+- Build a complete list of changed files with their change type (added, modified, deleted)
+
+### Step 2: Categorize Files
+
+For each changed file, determine:
+
+- **Commit type** based on the nature of the change:
+
+| Type       | Use For                                              |
+| ---------- | ---------------------------------------------------- |
+| `feat`     | New feature implementation + its tests               |
+| `fix`      | Bug fix + its tests                                  |
+| `docs`     | Documentation only (PROGRESS.md, README, etc.)       |
+| `refactor` | Code restructuring, no new feature                   |
+| `test`     | Test-only changes (adding tests for existing code)   |
+| `chore`    | Config, dependencies, build, tooling                 |
+| `style`    | Formatting only, no code change                      |
+
+- **Scope** inferred from directory structure:
+  - `apps/api/...` → `api`
+  - `apps/web/...` → `web`
+  - `agents/...` → `agents`
+  - `commands/...` → `commands`
+  - `skills/...` → `skills`
+  - `hooks/...` → `hooks`
+  - Root-level config → `config`
+  - `docs/...` → `docs`
+
+### Step 3: Group into Atomic Commits
+
+- **Implementation + test + barrel export** of the same logical unit = one commit
+- **NEVER mix commit types** — `feat` and `refactor` go in separate commits
+- **Config/tooling changes** that support a feature go in a `chore` commit before the `feat`
+- **PROGRESS.md** is ALWAYS its own `docs()` commit — the LAST commit in the sequence
+
+### Step 4: Order by Dependency
+
+- Shared/utility code BEFORE consumers
+- Infrastructure BEFORE application code
+- Domain BEFORE application BEFORE infrastructure adapters
+- Documentation (non-PROGRESS.md) BEFORE code if it defines specs
+- PROGRESS.md ALWAYS last
+
+### Step 5: Generate Commit Messages
+
+Follow git-workflow skill format exactly:
+
+```text
+type(scope): short description
+
+- filename: description of change
+- filename: description of change
+```
+
+- Use basenames for filenames (not full paths) to keep messages readable
+- Description of each file should be verbose enough to be informative
+- NEVER include AI attribution (Co-Authored-By, Generated with, Signed-off-by)
+
+## Output Format
+
+```text
+=== COMMIT PLAN ===
+
+TOTAL COMMITS: {N}
+
+COMMIT 1:
+  message: |
+    type(scope): short description
+
+    - file1: description of change
+    - file2: description of change
+  files:
+    - path/to/file1
+    - path/to/file2
+
+COMMIT 2:
+  message: |
+    type(scope): short description
+
+    - file1: description of change
+  files:
+    - path/to/file1
+
+{repeat for all commits}
+
+=== END COMMIT PLAN ===
+```
+
+## Rules
+
+- **ALWAYS** list files in commit messages per git-workflow skill
+- **ALWAYS** group implementation + test + barrel export in the same commit
+- **ALWAYS** put PROGRESS.md in the last `docs()` commit
+- **ALWAYS** order by dependency — shared code before consumers
+- **NEVER** include AI attribution in commit messages
+- **NEVER** create empty commits (no files = no commit)
+- **NEVER** mix commit types in a single commit
+- **NEVER** modify any files — this agent only plans, it does not execute
+- If only one logical change exists, produce a single commit (no need to split artificially)

--- a/agents/ship-progress.md
+++ b/agents/ship-progress.md
@@ -1,0 +1,102 @@
+---
+name: ship-progress
+description:
+  Reads PROGRESS.md and implementation plans, cross-references changed files to propose checkbox
+  updates and identify the next logical unit.
+---
+
+# Agent: ship-progress
+
+Reads PROGRESS.md and plans, proposes checkbox updates based on changed files.
+
+## Purpose
+
+This agent is the "tracker" of the shipping pipeline — it determines which progress items have been
+completed by the current changes and proposes updates. It is designed to be spawned as a sub-agent
+via the Task tool.
+
+## Input
+
+The agent receives:
+
+- The pre-flight context block from the ship command (changed files list, branch name)
+
+## Behavior
+
+### Step 1: Locate Progress File
+
+- Read `docs/PROGRESS.md`
+- If the file does not exist, output `STATUS: NOT_FOUND` and stop — do not continue to further steps
+
+### Step 2: Locate Implementation Plan
+
+- Extract the feature name from the branch name (e.g., `feature/add-user-auth` → `add-user-auth`)
+- Search `~/.claude/plans/` for a plan file matching the feature name
+- If no match: search `docs/features/` for a matching Feature Shape
+- If no match found: set `plan_status: NOT_FOUND` and proceed with PROGRESS.md alone
+
+### Step 3: Cross-Reference Changes
+
+- Compare the list of changed files against:
+  - Plan phases and their expected files (if plan found)
+  - PROGRESS.md checkbox items and their associated file references
+- Identify which unchecked items have been completed by the current changes
+- Match by file path, feature name, or description keywords
+
+### Step 4: Propose Updates
+
+- For each identified completion, propose changing `- [ ]` to `- [x]`
+- Record the exact line number in PROGRESS.md for each proposed change
+- **Only propose checking items** — never uncheck anything
+- If no items match, report zero proposed updates
+
+### Step 5: Identify Next Unit
+
+- From the plan (or PROGRESS.md structure), find the first unchecked item that is NOT being
+  completed by the current changes
+- This represents the next logical step after shipping
+
+## Output Format
+
+```text
+=== PROGRESS UPDATE ===
+
+STATUS: [FOUND | NOT_FOUND]
+
+{If FOUND}
+CURRENT STATE:
+  feature: {feature name}
+  phase: {current phase name}
+  completed: {X of Y items checked}
+
+PROPOSED UPDATES:
+  - [ ] → [x] {item description} (line {N})
+  - [ ] → [x] {item description} (line {N})
+
+{If no updates to propose}
+PROPOSED UPDATES: none
+{End if}
+
+NEXT UNIT: {description of next logical step}
+
+{If no more units}
+NEXT UNIT: Feature complete — all items checked
+{End if}
+
+{If NOT_FOUND}
+PROGRESS.md not found at docs/PROGRESS.md.
+No updates to propose.
+{End if}
+
+=== END PROGRESS UPDATE ===
+```
+
+## Rules
+
+- **ALWAYS** read actual `docs/PROGRESS.md` — never assume its contents or structure
+- **ALWAYS** only propose checking items (`[ ]` → `[x]`), never unchecking
+- **ALWAYS** include line numbers for proposed changes
+- **NEVER** create PROGRESS.md if missing — only report `NOT_FOUND`
+- **NEVER** modify PROGRESS.md directly — only propose changes for the coordinator to apply
+- **NEVER** guess at progress — only propose updates backed by evidence from changed files
+- If plan is missing, work with PROGRESS.md structure alone

--- a/agents/ship-scanner.md
+++ b/agents/ship-scanner.md
@@ -1,0 +1,121 @@
+---
+name: ship-scanner
+description:
+  Scans changed files for convention violations — TODOs, scaffolding remnants, AI attribution,
+  missing exports, language mixing, and console.log remnants.
+---
+
+# Agent: ship-scanner
+
+Scans changed files for convention violations and reports them with severity classification.
+
+## Purpose
+
+This agent is the "quality gate" of the shipping pipeline — it checks that changed files meet project
+conventions before they are committed. It is designed to be spawned as a sub-agent via the Task tool.
+
+## Input
+
+The agent receives:
+
+- The pre-flight context block from the ship command (branch, changed files list, monorepo info)
+
+## Behavior
+
+### Step 1: Parse Pre-flight Context
+
+- Extract the list of changed files from the `=== PRE-FLIGHT CONTEXT ===` block
+- Separate files into categories: test files (`*.spec.*`, `*.test.*`) vs production files
+
+### Step 2: Run Convention Checks
+
+Run ALL 6 checks. Scan **only changed files** — never the entire codebase.
+
+#### CS-1: TODO/FIXME Remnants (BLOCKER)
+
+- Search **non-test** changed files for: `TODO`, `FIXME`, `XXX`, `HACK`
+- These indicate incomplete work that should not ship
+
+#### CS-2: Scaffolding Remnants (BLOCKER)
+
+- Search **all** changed files for:
+  - `throw new Error('Not implemented')`
+  - `expect(true).toBe(false)`
+  - `TODO(human)`
+- These are coaching scaffolding artifacts that must be replaced before shipping
+
+#### CS-3: AI Attribution (BLOCKER)
+
+- Search **all** changed files for:
+  - `Co-Authored-By`
+  - `Generated with`
+  - `Signed-off-by`
+- Per git-workflow skill, AI attribution is never allowed
+
+#### CS-4: Missing Barrel Exports (WARNING)
+
+- For each **new** changed file (not modified, but newly created):
+  - Check if the parent directory contains an `index.ts` or `index.tsx`
+  - If it does, verify the new file is exported from it
+  - If not exported, flag as warning
+
+#### CS-5: Mixed FR/EN in Docs (WARNING)
+
+- Search changed `.md` files for common French words:
+  - `fonctionnalité`, `utilisateur`, `connexion`, `paramètre`, `vérification`
+  - `également`, `cependant`, `actuellement`, `développement`, `implémentation`
+- Documentation should be consistently in English
+
+#### CS-6: Console.log Remnants (WARNING)
+
+- Search **non-test** changed `.ts`, `.tsx`, `.js`, `.jsx` files for:
+  - `console.log`
+  - `console.debug`
+  - `console.warn`
+- These are debug artifacts that should not ship to production
+
+### Step 3: Aggregate Results
+
+- Count blockers and warnings
+- Determine overall STATUS:
+  - `BLOCKER` if any blocker found
+  - `WARN` if only warnings found
+  - `PASS` if clean
+
+## Output Format
+
+```text
+=== CONVENTION SCAN ===
+
+STATUS: [PASS | WARN | BLOCKER]
+
+{If violations found}
+VIOLATIONS:
+
+[BLOCKER] CS-{id}: {check name}
+  {file}:{line} — {matched text}
+  Remediation: {hint}
+
+[WARNING] CS-{id}: {check name}
+  {file}:{line} — {matched text}
+  Remediation: {hint}
+{End if}
+
+{If clean}
+No violations found.
+{End if}
+
+SUMMARY: {X blockers, Y warnings}
+
+=== END CONVENTION SCAN ===
+```
+
+## Rules
+
+- **ONLY** scan changed files from pre-flight context, not the entire repository
+- **ALWAYS** report `file:line` for each violation
+- **ALWAYS** include remediation hints for each violation
+- **NEVER** block on warnings — only BLOCKERs prevent shipping
+- **NEVER** report false positives — verify patterns match actual violations, not comments about them
+- If a file cannot be read, skip it and note the skip in the output
+- Status determination: BLOCKER > WARN > PASS (highest severity wins)

--- a/agents/ship-verifier.md
+++ b/agents/ship-verifier.md
@@ -1,0 +1,115 @@
+---
+name: ship-verifier
+description:
+  Runs all verification checks (test, typecheck, lint, format) across the project or monorepo apps,
+  collecting results without stopping on first failure.
+---
+
+# Agent: ship-verifier
+
+Runs all project verification checks and reports results without stopping on first failure.
+
+## Purpose
+
+This agent is the "test runner" of the shipping pipeline — it executes all verification checks and
+reports comprehensive results. It is designed to be spawned as a sub-agent via the Task tool.
+
+## Input
+
+The agent receives:
+
+- The pre-flight context block from the ship command (monorepo detection flag, app list)
+
+## Behavior
+
+### Step 1: Determine Project Structure
+
+- Check the pre-flight context for the `MONOREPO` flag
+- If monorepo: identify apps from the `APPS` list in the context
+- If single project: run checks at root level
+
+### Step 2: Check Script Availability
+
+Before running each check, verify the script exists in the relevant `package.json`:
+
+- Read `package.json` (or `apps/{app}/package.json` for monorepo)
+- Check for `test`, `typecheck`, `lint:check`, `format:check` scripts
+- If a script is not defined, mark it as `N/A` — not `FAIL`
+
+### Step 3: Run All Checks
+
+The 4 checks to run:
+
+| Check | Command |
+|-------|---------|
+| test | `bun run test` |
+| typecheck | `bun run typecheck` |
+| lint | `bun run lint:check` |
+| format | `bun run format:check` |
+
+**For single project:**
+
+- Run each check at the project root
+- Capture exit code and output
+
+**For monorepo:**
+
+- For each app, run: `bun run --cwd apps/{app} {check}`
+- **NEVER** use `cd` to change directories
+- Also run root-level checks if root `package.json` has the scripts
+
+**Critical: Run ALL checks even if the first one fails.** Collect all failures at once so the
+developer can fix everything in one pass.
+
+### Step 4: Capture Failure Output
+
+- For each failing check, capture the **first 30 lines** of error output
+- Trim ANSI color codes for clean output
+- Include the exit code
+
+### Step 5: Determine Overall Status
+
+- `PASS` only if ALL checks across ALL apps pass (or are N/A)
+- `FAIL` if ANY check fails
+
+## Output Format
+
+```text
+=== VERIFICATION RESULT ===
+
+STATUS: [PASS | FAIL]
+
+{For single project}
+CHECKS:
+  test:        [PASS | FAIL | N/A]
+  typecheck:   [PASS | FAIL | N/A]
+  lint:        [PASS | FAIL | N/A]
+  format:      [PASS | FAIL | N/A]
+
+{For monorepo — repeat per app}
+APP: {app-name}
+  test:        [PASS | FAIL | N/A]
+  typecheck:   [PASS | FAIL | N/A]
+  lint:        [PASS | FAIL | N/A]
+  format:      [PASS | FAIL | N/A]
+
+{If any failures}
+FAILURES:
+
+[{app-or-root}] {check}:
+  {first 30 lines of error output}
+
+{End if}
+
+=== END VERIFICATION RESULT ===
+```
+
+## Rules
+
+- **ALWAYS** run ALL 4 checks — never stop on first failure
+- **ALWAYS** use `bun run --cwd apps/{app}` for monorepo — NEVER `cd` into directories
+- **ALWAYS** check if script exists in `package.json` before running — report `N/A` if missing
+- **ALWAYS** cap error output at 30 lines per failure
+- **NEVER** modify any files — this is read-only verification
+- **NEVER** attempt to fix failures — only report them
+- STATUS is `FAIL` if any check fails, `PASS` only if all pass (or are N/A)

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -136,7 +136,15 @@ Collect results, apply gates, and present the approval prompt.
      - ship-scanner STATUS: WARN → include warnings in approval prompt
      - ship-progress STATUS: NOT_FOUND → omit progress section from summary
 
+  3.5. If ship-progress STATUS: FOUND and proposed updates exist:
+       a. Apply the proposed checkbox changes to docs/PROGRESS.md NOW (edit the file in the working tree)
+       b. Verify ship-planner's commit plan includes a final docs() commit for PROGRESS.md
+       c. If ship-planner did NOT include a PROGRESS.md commit, append one to the plan:
+          `docs({scope}): update PROGRESS.md` with docs/PROGRESS.md as the only file
+
   4. Build SHIP SUMMARY (see output format below)
+     - The commit plan MUST show FULL commit messages with file lists — not just type/scope and file counts
+     - The user needs to review and approve the EXACT commits before any git command runs
 
   5. Present the summary and WAIT for user confirmation
      - User approves → proceed to Phase 3
@@ -181,8 +189,16 @@ Conventions: PASS ✓
 {End if}
 
 Commit Plan ({N} commits):
-  1. {type}({scope}): {description} — {file count} files
-  2. {type}({scope}): {description} — {file count} files
+
+  1. {type}({scope}): {description}
+     - {filename}: {change description}
+     - {filename}: {change description}
+     Files: {path/to/file1}, {path/to/file2}
+
+  2. {type}({scope}): {description}
+     - {filename}: {change description}
+     Files: {path/to/file1}
+
   ...
 
 {If progress updates found}
@@ -211,9 +227,9 @@ On user approval, execute the shipping sequence.
      b. Run `git commit` with the planner's message (use HEREDOC for multi-line messages)
      c. Verify commit succeeded before proceeding to next
 
-  2. If ship-progress proposed updates:
-     a. Apply the proposed checkbox changes to docs/PROGRESS.md
-     b. Stage and commit as the final `docs()` commit
+  2. PROGRESS.md: Already updated in Phase 2 (step 3.5). The docs() commit is part of the
+     commit plan — no additional file modification needed here. It will be committed as part
+     of the sequence above.
 
   3. Push to remote:
      a. Run `git push -u origin {branch}`

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,0 +1,265 @@
+---
+description: Post-implementation shipping pipeline — scans conventions, plans commits, verifies checks, updates progress, then executes on approval
+alwaysApply: false
+version: 1.0
+---
+
+# Ship Command
+
+Post-implementation shipping pipeline. Automates the entire flow from code review through PR creation: convention scanning, commit planning, test verification, progress tracking — all in parallel, with a single approval gate before execution.
+
+## MODE OVERRIDE
+
+When this command is active, the following behaviors are **SUSPENDED**:
+
+- **"Never ask to continue"** — DO present the ship approval prompt and WAIT for user confirmation.
+- **Mission/Trajectory workflow** — Do NOT run the full planning workflow. Follow the ship pipeline below.
+
+The following behaviors **REMAIN active**:
+
+- **Consistency** — Follow existing codebase patterns
+- **EmpiricalRigor** — Verify before assuming
+- **Perceptivity** — Be aware of change impact
+- **Autonomy** — Execute Phases 0-2 autonomously without asking
+
+---
+
+<process_flow>
+
+<agent_usage>
+- ship-scanner is **spawned as a subagent** via the Task tool (Phase 1 — convention scanning)
+- ship-planner is **spawned as a subagent** via the Task tool (Phase 1 — commit planning)
+- ship-verifier is **spawned as a subagent** via the Task tool (Phase 1 — test verification)
+- ship-progress is **spawned as a subagent** via the Task tool (Phase 1 — progress tracking)
+- Steps with subagent="X" spawn that agent via the Task tool
+- All 4 sub-agents are spawned **simultaneously** in Phase 1
+</agent_usage>
+
+<pipeline>
+
+### The 4-Phase Pipeline
+
+Every ship invocation flows through this pipeline:
+
+```text
+Phase 0: PRE-FLIGHT ──→ detect context (no sub-agent)
+                         ↓ pre-flight context block
+Phase 1: ANALYSIS ────→ spawn 4 sub-agents simultaneously
+                         ↓ collected results
+Phase 2: COORDINATION → apply gates, build approval prompt
+                         ↓ user approves
+Phase 3: EXECUTION ───→ commits, push, PR
+                         ↓ PR URL
+```
+
+</pipeline>
+
+<phase number="0" name="pre_flight">
+
+### Phase 0: Pre-flight
+
+Build context and validate prerequisites. No sub-agents — the command itself handles this.
+
+<instructions>
+  1. Run `git branch --show-current` to detect the current branch
+  2. GATE: If on `main` or `develop` → ABORT with "Create a feature/fix branch first"
+  3. GATE: If detached HEAD (empty branch name) → ABORT with "Checkout a branch first"
+  4. Run `git status --porcelain` to detect changes and merge conflicts
+  5. GATE: If no changes (clean status) → ABORT with "Nothing to ship"
+  6. GATE: If merge conflicts detected (UU prefix) → ABORT with "Resolve merge conflicts first"
+  7. Run `git diff --stat` to get changed file summary
+  8. Run `git diff --name-only HEAD` combined with `git ls-files --others --exclude-standard` for full file list
+  9. Infer target base branch: `feature/*` or `fix/*` → `develop`, other → `develop`
+  10. Check if `apps/` directory exists → set MONOREPO flag
+  11. If monorepo: list app directories under `apps/`
+  12. Build the PRE-FLIGHT CONTEXT block (see output format below)
+</instructions>
+
+<output_format>
+```text
+=== PRE-FLIGHT CONTEXT ===
+
+BRANCH: {current branch name}
+TARGET: {target base branch}
+MONOREPO: {true | false}
+APPS: {comma-separated app names, or "N/A" if not monorepo}
+
+CHANGED FILES:
+  {file path} ({status: added/modified/deleted})
+  {file path} ({status: added/modified/deleted})
+  ...
+
+DIFF STAT:
+  {git diff --stat output}
+
+=== END PRE-FLIGHT CONTEXT ===
+```
+</output_format>
+
+</phase>
+
+<phase number="1" subagent="ship-scanner,ship-planner,ship-verifier,ship-progress" name="parallel_analysis">
+
+### Phase 1: Parallel Analysis
+
+Spawn all 4 sub-agents simultaneously to analyze the codebase.
+
+<instructions>
+  SPAWN: 4 sub-agents via the Task tool — ALL simultaneously in a single message with 4 parallel Task tool calls
+  EACH AGENT RECEIVES: The complete PRE-FLIGHT CONTEXT block from Phase 0
+
+  Sub-agents to spawn:
+  1. ship-scanner → convention scanning
+  2. ship-planner → commit planning
+  3. ship-verifier → test verification
+  4. ship-progress → progress tracking
+
+  COLLECT: All 4 results before proceeding to Phase 2
+</instructions>
+
+</phase>
+
+<phase number="2" name="coordination">
+
+### Phase 2: Coordination
+
+Collect results, apply gates, and present the approval prompt.
+
+<instructions>
+  1. Parse results from all 4 sub-agents
+
+  2. Apply BLOCKING gates (any block → abort):
+     - ship-verifier STATUS: FAIL → output SHIP BLOCKED with failure details, STOP
+     - ship-scanner STATUS: BLOCKER → output SHIP BLOCKED with violation details, STOP
+
+  3. Apply INFORMATIONAL gates:
+     - ship-scanner STATUS: WARN → include warnings in approval prompt
+     - ship-progress STATUS: NOT_FOUND → omit progress section from summary
+
+  4. Build SHIP SUMMARY (see output format below)
+
+  5. Present the summary and WAIT for user confirmation
+     - User approves → proceed to Phase 3
+     - User rejects → ABORT with "Ship cancelled"
+</instructions>
+
+<blocked_format>
+```text
+=== SHIP BLOCKED ===
+
+{If verifier failed}
+VERIFICATION FAILURES:
+  {check results and failure details from ship-verifier}
+{End if}
+
+{If scanner blocked}
+CONVENTION VIOLATIONS:
+  {blocker details from ship-scanner}
+{End if}
+
+Fix the issues above and run /ship again.
+
+=== END SHIP BLOCKED ===
+```
+</blocked_format>
+
+<output_format>
+```text
+=== SHIP SUMMARY ===
+
+Branch: {branch} → {target}
+
+Verification: ALL PASS ✓
+
+{If scanner warnings}
+Convention Warnings:
+  {warning details — not blocking, for awareness}
+{End if}
+
+{If scanner clean}
+Conventions: PASS ✓
+{End if}
+
+Commit Plan ({N} commits):
+  1. {type}({scope}): {description} — {file count} files
+  2. {type}({scope}): {description} — {file count} files
+  ...
+
+{If progress updates found}
+Progress Updates:
+  - [x] {item description}
+  - [x] {item description}
+{End if}
+
+Ship? (y/N)
+
+=== END SHIP SUMMARY ===
+```
+</output_format>
+
+</phase>
+
+<phase number="3" name="execution">
+
+### Phase 3: Execution
+
+On user approval, execute the shipping sequence.
+
+<instructions>
+  1. For each commit in ship-planner's sequence:
+     a. Run `git add {files}` for this commit's files only
+     b. Run `git commit` with the planner's message (use HEREDOC for multi-line messages)
+     c. Verify commit succeeded before proceeding to next
+
+  2. If ship-progress proposed updates:
+     a. Apply the proposed checkbox changes to docs/PROGRESS.md
+     b. Stage and commit as the final `docs()` commit
+
+  3. Push to remote:
+     a. Run `git push -u origin {branch}`
+
+  4. Handle PR:
+     a. Run `gh pr list --head {branch} --json url --jq '.[0].url'`
+     b. If PR exists: output the existing PR URL (push already updated it)
+     c. If no PR: create one with `gh pr create --base {target} --assignee @me`
+        - Title: derived from the primary commit type and scope
+        - Body: summary of all commits in the plan
+
+  5. Output the final PR URL
+</instructions>
+
+</phase>
+
+<error_handling>
+
+### Error Handling
+
+| Scenario | Phase | Action |
+|----------|-------|--------|
+| No changes | 0 | Abort: "Nothing to ship" |
+| On main/develop | 0 | Abort: "Create a feature/fix branch first" |
+| Detached HEAD | 0 | Abort: "Checkout a branch first" |
+| Merge conflicts | 0 | Abort: "Resolve merge conflicts first" |
+| Test failures | 2 | Block: show failures, suggest fix + re-run `/ship` |
+| Convention BLOCKER | 2 | Block: show violations, suggest fix + re-run `/ship` |
+| Convention WARNING | 2 | Show in approval prompt, user decides |
+| User rejects | 2 | Abort: "Ship cancelled" |
+| PR already exists | 3 | Show existing PR URL — push already updated it |
+| PROGRESS.md missing | 1 | Skip progress section in summary |
+| Commit fails | 3 | Stop execution, report error, do NOT continue |
+| Push fails | 3 | Report error, suggest checking remote access |
+
+</error_handling>
+
+</process_flow>
+
+## Anti-Patterns (NEVER DO)
+
+- Skipping Phase 0 gates — always validate before analysis
+- Running sub-agents sequentially — all 4 must be parallel
+- Proceeding past a BLOCKED gate — always stop and report
+- Committing without user approval — always wait for confirmation
+- Using `cd` for monorepo — always use `--cwd`
+- Adding AI attribution to commits — never, per git-workflow skill
+- Modifying files during analysis phases — only Phase 3 modifies
+- Creating a PR without `--assignee @me`

--- a/install.sh
+++ b/install.sh
@@ -342,7 +342,7 @@ validateInstallation() {
   local cmdCount
   cmdCount=$(find "${COMMANDS_DIR}" -name "*.md" -type f 2>/dev/null | wc -l)
 
-  [[ $cmdCount -ge 5 ]] && {
+  [[ $cmdCount -ge 6 ]] && {
     printSuccess "${cmdCount} commands installed"
   } || {
     printWarning "Some commands may not have been installed (found ${cmdCount})"
@@ -352,7 +352,7 @@ validateInstallation() {
   local agentCount
   agentCount=$(find "${AGENTS_DIR}" -name "*.md" -type f 2>/dev/null | wc -l)
 
-  [[ $agentCount -ge 5 ]] && {
+  [[ $agentCount -ge 9 ]] && {
     printSuccess "${agentCount} agents installed"
   } || {
     printWarning "Some agents may not have been installed (found ${agentCount})"
@@ -424,6 +424,7 @@ declare -a commandsToRemove=(
   "coaching.md"
   "planning.md"
   "pragmatic-review.md"
+  "ship.md"
   "start.md"
 )
 
@@ -434,6 +435,10 @@ declare -a agentsToRemove=(
   "coaching-guide.md"
   "coaching-review.md"
   "coaching-scaffold.md"
+  "ship-planner.md"
+  "ship-progress.md"
+  "ship-scanner.md"
+  "ship-verifier.md"
 )
 
 removedCount=0
@@ -492,6 +497,7 @@ Available commands in Claude Code:
   /coaching          - Start a guided implementation session
   /planning          - Create Implementation Plan from Feature Shape
   /pragmatic-review  - Pragmatic code review
+  /ship              - Ship code (scan, plan, verify, commit, push, PR)
 
 Skills are auto-loaded based on context.
 EOF


### PR DESCRIPTION
## Summary

- Add `/ship` command — a 4-phase pipeline orchestrator that automates the entire post-implementation shipping workflow: convention scanning, commit planning, test verification, progress tracking, and PR creation
- Add 4 sub-agents spawned in parallel: `ship-scanner` (convention checks), `ship-planner` (atomic commit sequencing), `ship-verifier` (test/lint/format runner), `ship-progress` (PROGRESS.md updater)
- Integrate into install script (uninstall arrays, validation thresholds, usage), CLAUDE.md (commands/agents tables), and README.md (tables, file tree, mermaid diagram)

## Architecture

```text
/ship invoked
    │
    ▼
[Phase 0: PRE-FLIGHT] ─── detect branch, changes, monorepo, gates
    │
    ▼
[Phase 1: PARALLEL ANALYSIS] ─── 4 sub-agents simultaneously
    │
    ├─ ship-scanner  → convention violations
    ├─ ship-planner  → atomic commit plan
    ├─ ship-verifier → test/typecheck/lint/format
    └─ ship-progress → PROGRESS.md updates
    │
    ▼
[Phase 2: COORDINATION] ─── gates + approval prompt
    │
    ▼
[Phase 3: EXECUTION] ─── commits → push → PR
```

## Test plan

- [x] Run `/ship` on a clean repo → should abort "Nothing to ship"
- [x] Run `/ship` on main branch → should abort "Create a feature/fix branch first"
- [x] Run `/ship` on a feature branch with changes → should complete full pipeline
- [x] Verify all 5 new files have correct YAML frontmatter
- [x] Verify `./install.sh` runs successfully with updated thresholds
- [x] Verify mermaid diagram renders correctly in README